### PR TITLE
feat(ingestion): add data loading script and dataset readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore raw data
+data/*.csv
+data/*.xlsx
+
+# Keep README
+!data/README.md

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,7 @@
+# Data Folder
+
+This folder contains the raw Lending Club dataset used in the MSc thesis project.  
+The actual dataset files (CSV, XLSX) are **not included** in the repository for size and confidentiality reasons.
+
+- `loan.csv` (raw dataset, ignored in Git)
+- `LCDataDictionary.xlsx` (metadata dictionary, ignored in Git)

--- a/src/ingestion/python_load_data.py
+++ b/src/ingestion/python_load_data.py
@@ -1,0 +1,7 @@
+import pandas as pd
+
+# Load raw dataset
+df = pd.read_csv("data/loan.csv")
+
+# Quick check: print shape (rows, columns)
+print(df.shape)


### PR DESCRIPTION
This PR adds:
- Python script (src/ingestion/python_load_data.py) for loading the Lending Club dataset
- README update describing the dataset files
- .gitignore for excluding raw CSV/XLSX files