### PR TITLE
PIPE-3: add .gitignore for raw/raw-like files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore raw data
+data/*.csv
+data/*.xlsx
+
+# Keep README
+!data/README.md


### PR DESCRIPTION
### Summary
This PR adds a `.gitignore` file to exclude raw dataset files (`.csv`, `.xlsx`) 
from being committed to Git. Only the dataset documentation (`README.md`) is kept.

### Jira
Resolves PIPE-3